### PR TITLE
fix: derive_pub() as infalible function

### DIFF
--- a/bitcoin/src/bip32.rs
+++ b/bitcoin/src/bip32.rs
@@ -16,7 +16,7 @@ use secp256k1::{Secp256k1, XOnlyPublicKey};
 use crate::crypto::key::{CompressedPublicKey, Keypair, PrivateKey};
 use crate::internal_macros::impl_array_newtype_stringify;
 use crate::network::NetworkKind;
-use crate::prelude::{Vec, String};
+use crate::prelude::{String, Vec};
 
 /// Version bytes for extended public keys on the Bitcoin network.
 const VERSION_BYTES_MAINNET_PUBLIC: [u8; 4] = [0x04, 0x88, 0xB2, 0x1E];
@@ -114,17 +114,55 @@ internals::serde_string_impl!(Xpub, "a BIP-32 extended public key");
 /// A child number for a derived key
 #[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Hash)]
 pub enum ChildNumber {
-    /// Non-hardened key
-    Normal {
-        /// Key index, within [0, 2^31 - 1]
-        index: u32,
-    },
-    /// Hardened key
-    Hardened {
-        /// Key index, within [0, 2^31 - 1]
-        index: u32,
-    },
+    /// A normal child number
+    Normal { index: u32 },
+    /// A hardened child number
+    Hardened { index: u32 },
 }
+
+/// A number expected to be a normal one
+pub struct NormalChildNumber(u32);
+
+/// A derivation path that is made up of normal child numbers
+pub struct NormalDerivationPath(Vec<NormalChildNumber>);
+
+/// A number expected to be a hardened one
+pub struct HardenedChildNumber(u32);
+
+impl TryInto<HardenedChildNumber> for ChildNumber {
+    type Error = Error;
+
+    fn try_into(self) -> Result<HardenedChildNumber, Error> {
+        match self {
+            ChildNumber::Normal { .. } => Err(Error::CannotDeriveFromHardenedKey),
+            ChildNumber::Hardened { index } => Ok(HardenedChildNumber(index)),
+        }
+    }
+}
+
+impl TryInto<NormalChildNumber> for ChildNumber {
+    type Error = Error;
+
+    fn try_into(self) -> Result<NormalChildNumber, Error> {
+        match self {
+            ChildNumber::Normal { index } => Ok(NormalChildNumber(index)),
+            ChildNumber::Hardened { .. } => Err(Error::CannotDeriveFromHardenedKey),
+        }
+    }
+}
+
+impl Into<ChildNumber> for HardenedChildNumber {
+    fn into(self) -> ChildNumber {
+        ChildNumber::Hardened { index: self.0 }
+    }
+}
+
+impl Into<ChildNumber> for NormalChildNumber {
+    fn into(self) -> ChildNumber {
+        ChildNumber::Normal { index: self.0 }
+    }
+}
+
 impl ChildNumber {
     /// Normal child number with index 0.
     pub const ZERO_NORMAL: Self = ChildNumber::Normal { index: 0 };
@@ -165,7 +203,9 @@ impl ChildNumber {
     /// Returns `true` if the child number is a [`Normal`] value.
     ///
     /// [`Normal`]: #variant.Normal
-    pub fn is_normal(&self) -> bool { !self.is_hardened() }
+    pub fn is_normal(&self) -> bool {
+        !self.is_hardened()
+    }
 
     /// Returns `true` if the child number is a [`Hardened`] value.
     ///
@@ -234,7 +274,9 @@ impl FromStr for ChildNumber {
 }
 
 impl AsRef<[ChildNumber]> for ChildNumber {
-    fn as_ref(&self) -> &[ChildNumber] { slice::from_ref(self) }
+    fn as_ref(&self) -> &[ChildNumber] {
+        slice::from_ref(self)
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -278,38 +320,54 @@ where
     type Output = <Vec<ChildNumber> as Index<I>>::Output;
 
     #[inline]
-    fn index(&self, index: I) -> &Self::Output { &self.0[index] }
+    fn index(&self, index: I) -> &Self::Output {
+        &self.0[index]
+    }
 }
 
 impl Default for DerivationPath {
-    fn default() -> DerivationPath { DerivationPath::master() }
+    fn default() -> DerivationPath {
+        DerivationPath::master()
+    }
 }
 
 impl<T> IntoDerivationPath for T
 where
     T: Into<DerivationPath>,
 {
-    fn into_derivation_path(self) -> Result<DerivationPath, Error> { Ok(self.into()) }
+    fn into_derivation_path(self) -> Result<DerivationPath, Error> {
+        Ok(self.into())
+    }
 }
 
 impl IntoDerivationPath for String {
-    fn into_derivation_path(self) -> Result<DerivationPath, Error> { self.parse() }
+    fn into_derivation_path(self) -> Result<DerivationPath, Error> {
+        self.parse()
+    }
 }
 
 impl<'a> IntoDerivationPath for &'a str {
-    fn into_derivation_path(self) -> Result<DerivationPath, Error> { self.parse() }
+    fn into_derivation_path(self) -> Result<DerivationPath, Error> {
+        self.parse()
+    }
 }
 
 impl From<Vec<ChildNumber>> for DerivationPath {
-    fn from(numbers: Vec<ChildNumber>) -> Self { DerivationPath(numbers) }
+    fn from(numbers: Vec<ChildNumber>) -> Self {
+        DerivationPath(numbers)
+    }
 }
 
 impl From<DerivationPath> for Vec<ChildNumber> {
-    fn from(path: DerivationPath) -> Self { path.0 }
+    fn from(path: DerivationPath) -> Self {
+        path.0
+    }
 }
 
 impl<'a> From<&'a [ChildNumber]> for DerivationPath {
-    fn from(numbers: &'a [ChildNumber]) -> Self { DerivationPath(numbers.to_vec()) }
+    fn from(numbers: &'a [ChildNumber]) -> Self {
+        DerivationPath(numbers.to_vec())
+    }
 }
 
 impl core::iter::FromIterator<ChildNumber> for DerivationPath {
@@ -324,11 +382,15 @@ impl core::iter::FromIterator<ChildNumber> for DerivationPath {
 impl<'a> core::iter::IntoIterator for &'a DerivationPath {
     type Item = &'a ChildNumber;
     type IntoIter = slice::Iter<'a, ChildNumber>;
-    fn into_iter(self) -> Self::IntoIter { self.0.iter() }
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
 }
 
 impl AsRef<[ChildNumber]> for DerivationPath {
-    fn as_ref(&self) -> &[ChildNumber] { &self.0 }
+    fn as_ref(&self) -> &[ChildNumber] {
+        &self.0
+    }
 }
 
 impl FromStr for DerivationPath {
@@ -375,17 +437,25 @@ impl<'a> Iterator for DerivationPathIterator<'a> {
 
 impl DerivationPath {
     /// Returns length of the derivation path
-    pub fn len(&self) -> usize { self.0.len() }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 
     /// Returns `true` if the derivation path is empty
-    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 
     /// Returns derivation path for a master key (i.e. empty derivation path)
-    pub fn master() -> DerivationPath { DerivationPath(vec![]) }
+    pub fn master() -> DerivationPath {
+        DerivationPath(vec![])
+    }
 
     /// Returns whether derivation path represents master key (i.e. it's length
     /// is empty). True for `m` path.
-    pub fn is_master(&self) -> bool { self.0.is_empty() }
+    pub fn is_master(&self) -> bool {
+        self.0.is_empty()
+    }
 
     /// Create a new [DerivationPath] that is a child of this one.
     pub fn child(&self, cn: ChildNumber) -> DerivationPath {
@@ -451,7 +521,9 @@ impl DerivationPath {
     /// const HARDENED: u32 = 0x80000000;
     /// assert_eq!(path.to_u32_vec(), vec![84 + HARDENED, HARDENED, HARDENED, 0, 1]);
     /// ```
-    pub fn to_u32_vec(&self) -> Vec<u32> { self.into_iter().map(|&el| el.into()).collect() }
+    pub fn to_u32_vec(&self) -> Vec<u32> {
+        self.into_iter().map(|&el| el.into()).collect()
+    }
 
     /// Creates a derivation path from a slice of u32s.
     /// ```
@@ -482,7 +554,9 @@ impl fmt::Display for DerivationPath {
 }
 
 impl fmt::Debug for DerivationPath {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { fmt::Display::fmt(&self, f) }
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self, f)
+    }
 }
 
 /// Full information on the used extended public key: fingerprint of the
@@ -524,20 +598,24 @@ impl fmt::Display for Error {
         use Error::*;
 
         match *self {
-            CannotDeriveFromHardenedKey =>
-                f.write_str("cannot derive hardened key from public key"),
+            CannotDeriveFromHardenedKey => {
+                f.write_str("cannot derive hardened key from public key")
+            }
             Secp256k1(ref e) => write_err!(f, "secp256k1 error"; e),
-            InvalidChildNumber(ref n) =>
-                write!(f, "child number {} is invalid (not within [0, 2^31 - 1])", n),
+            InvalidChildNumber(ref n) => {
+                write!(f, "child number {} is invalid (not within [0, 2^31 - 1])", n)
+            }
             InvalidChildNumberFormat => f.write_str("invalid child number format"),
             InvalidDerivationPathFormat => f.write_str("invalid derivation path format"),
             UnknownVersion(ref bytes) => write!(f, "unknown version magic bytes: {:?}", bytes),
-            WrongExtendedKeyLength(ref len) =>
-                write!(f, "encoded extended key data has wrong length {}", len),
+            WrongExtendedKeyLength(ref len) => {
+                write!(f, "encoded extended key data has wrong length {}", len)
+            }
             Base58(ref e) => write_err!(f, "base58 encoding error"; e),
             Hex(ref e) => write_err!(f, "Hexadecimal decoding error"; e),
-            InvalidPublicKeyHexLength(got) =>
-                write!(f, "PublicKey hex should be 66 or 130 digits long, got: {}", got),
+            InvalidPublicKeyHexLength(got) => {
+                write!(f, "PublicKey hex should be 66 or 130 digits long, got: {}", got)
+            }
             InvalidBase58PayloadLength(ref e) => write_err!(f, "base58 payload"; e),
         }
     }
@@ -565,15 +643,21 @@ impl std::error::Error for Error {
 }
 
 impl From<secp256k1::Error> for Error {
-    fn from(e: secp256k1::Error) -> Error { Error::Secp256k1(e) }
+    fn from(e: secp256k1::Error) -> Error {
+        Error::Secp256k1(e)
+    }
 }
 
 impl From<base58::Error> for Error {
-    fn from(err: base58::Error) -> Self { Error::Base58(err) }
+    fn from(err: base58::Error) -> Self {
+        Error::Base58(err)
+    }
 }
 
 impl From<InvalidBase58PayloadLengthError> for Error {
-    fn from(e: InvalidBase58PayloadLengthError) -> Error { Self::InvalidBase58PayloadLength(e) }
+    fn from(e: InvalidBase58PayloadLengthError) -> Error {
+        Self::InvalidBase58PayloadLength(e)
+    }
 }
 
 impl Xpriv {
@@ -724,16 +808,36 @@ impl Xpub {
     }
 
     /// Constructs ECDSA compressed public key matching internal public key representation.
-    pub fn to_pub(self) -> CompressedPublicKey { CompressedPublicKey(self.public_key) }
+    pub fn to_pub(self) -> CompressedPublicKey {
+        CompressedPublicKey(self.public_key)
+    }
 
     /// Constructs BIP340 x-only public key for BIP-340 signatures and Taproot use matching
     /// the internal public key representation.
-    pub fn to_x_only_pub(self) -> XOnlyPublicKey { XOnlyPublicKey::from(self.public_key) }
+    pub fn to_x_only_pub(self) -> XOnlyPublicKey {
+        XOnlyPublicKey::from(self.public_key)
+    }
+
+    /// Derive an extended public key from a path when certain of it being a Normalized number.
+    ///
+    /// The `path` argument can be any type implementing `AsRef<ChildNumber>`, such as `DerivationPath`, for instance.
+    pub fn derive_pub<C: secp256k1::Verification, P: AsRef<[NormalChildNumber]>>(
+        &self,
+        secp: &Secp256k1<C>,
+        path: &P,
+    ) -> Xpub {
+        let mut pk: Xpub = *self;
+        for cnum in path.as_ref() {
+            let cnum: ChildNumber = cnum.0.into();
+            pk = pk.ckd_pub(secp, cnum).expect("Will never fail");
+        }
+        pk
+    }
 
     /// Attempts to derive an extended public key from a path.
     ///
     /// The `path` argument can be any type implementing `AsRef<ChildNumber>`, such as `DerivationPath`, for instance.
-    pub fn derive_pub<C: secp256k1::Verification, P: AsRef<[ChildNumber]>>(
+    pub fn try_derive_pub<C: secp256k1::Verification, P: AsRef<[ChildNumber]>>(
         &self,
         secp: &Secp256k1<C>,
         path: &P,
@@ -785,7 +889,6 @@ impl Xpub {
             chain_code,
         })
     }
-
     /// Decoding extended public key from binary data according to BIP 32
     pub fn decode(data: &[u8]) -> Result<Xpub, Error> {
         if data.len() != 78 {
@@ -882,11 +985,15 @@ impl FromStr for Xpub {
 }
 
 impl From<Xpub> for XKeyIdentifier {
-    fn from(key: Xpub) -> XKeyIdentifier { key.identifier() }
+    fn from(key: Xpub) -> XKeyIdentifier {
+        key.identifier()
+    }
 }
 
 impl From<&Xpub> for XKeyIdentifier {
-    fn from(key: &Xpub) -> XKeyIdentifier { key.identifier() }
+    fn from(key: &Xpub) -> XKeyIdentifier {
+        key.identifier()
+    }
 }
 
 /// Decoded base58 data was an invalid length.
@@ -898,7 +1005,9 @@ pub struct InvalidBase58PayloadLengthError {
 
 impl InvalidBase58PayloadLengthError {
     /// Returns the invalid payload length.
-    pub fn invalid_base58_payload_length(&self) -> usize { self.length }
+    pub fn invalid_base58_payload_length(&self) -> usize {
+        self.length
+    }
 }
 
 impl fmt::Display for InvalidBase58PayloadLengthError {


### PR DESCRIPTION
After thinking for a bit, this is the best way we can do this.
Why:
- is simple.
- the function tells whats expecting.
- No change on internals.
- No iterator